### PR TITLE
fetch updated RDS CA bundle

### DIFF
--- a/project/SecureDockerfile.scala
+++ b/project/SecureDockerfile.scala
@@ -1,15 +1,17 @@
 import sbtdocker.Dockerfile
 
-/** A dockerfile that contains the AWS root cert in the place where
-  * postgres expects to find it (~/.postgresql/root.crt).
-  */
+// A Dockerfile that contains the AWS RDS CA root certificate
+// Assumes the current user is pennsieve
 abstract class SecureDockerfile(image: String) extends Dockerfile {
+  // Where Postgres (psql/JDBC) expects to find the trusted CA certificate
+  val CA_CERT_LOCATION = "/home/pennsieve/.postgresql/root.crt"
+
   from(image)
-  run("mkdir", "-p", "/home/pennsieve/.postgresql")
-  run(
-    "wget",
-    "-qO",
-    "/home/pennsieve/.postgresql/root.crt",
-    "https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem"
+  addRaw(
+    "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
+    CA_CERT_LOCATION,
   )
+  user("root")
+  run("chmod", "+r", CA_CERT_LOCATION)
+  user("pennsieve")
 }


### PR DESCRIPTION
## Changes Proposed
**ClickUp Ticket:** [8688dguvj](https://app.clickup.com/t/8688dguvj)

Upgrading the CA we pull down to trust when connecting to our PostgreSQL database using `ssl_mode=verify-ca`. The old CA is set to expire in August 2024 so we will need to upgrade our RDS CA. This change allows us to do that without introducing downtime.

## Testing
Built and ran the images locally to ensure the new CA cert bundle was put in the right location.

Tested using the bundle separately:
- locally (from the dev jump box) using the bundled PEM in place of the single expiring certificate.
- with a JDBC connection via the pennsieve-api repo in: https://github.com/Pennsieve/pennsieve-api/pull/287

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
