### PR TITLE
Add permissions for RE-JOIN and Precision buckets

### DIFF
--- a/discover-publish/terraform/iam.tf
+++ b/discover-publish/terraform/iam.tf
@@ -123,6 +123,18 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_storage_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn}/*",
 
     ]
   }

--- a/discover-publish/terraform/iam.tf
+++ b/discover-publish/terraform/iam.tf
@@ -158,6 +158,14 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn}/*",
     ]
   }
 
@@ -185,6 +193,14 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn}/*",
     ]
   }
 
@@ -202,6 +218,10 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       data.terraform_remote_state.platform_infrastructure.outputs.discover_embargo50_bucket_arn,
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn,
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
     ]
   }
 
@@ -215,6 +235,10 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       data.terraform_remote_state.platform_infrastructure.outputs.discover_embargo50_bucket_arn,
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn,
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
     ]
   }
 
@@ -240,6 +264,14 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn}/*",
     ]
   }
 
@@ -257,6 +289,14 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn}/*",
     ]
   }
 


### PR DESCRIPTION
## Changes Proposed

Adds the custom buckets from aws-rejoin to IAM policies.


