### PR TITLE
Update task definition resource reference to include version wildcard

### DIFF
--- a/discover-publish/terraform/iam.tf
+++ b/discover-publish/terraform/iam.tf
@@ -302,8 +302,8 @@ data "aws_iam_policy_document" "sfn_state_machine_iam_policy_document" {
     ]
 
     resources = [
-      local.discover_publish_task_definition_family,
-      local.model_publish_task_definition_family,
+      local.discover_publish_task_definition_arn_wildcard_version,
+      local.model_publish_task_definition_arn_wildcard_version,
     ]
   }
 

--- a/discover-publish/terraform/variables.tf
+++ b/discover-publish/terraform/variables.tf
@@ -67,10 +67,12 @@ locals {
   #
   model_publish_arn_components = split(":", data.terraform_remote_state.model_publish.outputs.ecs_task_definition_arn)
   model_publish_task_definition_family = join(":", slice(local.model_publish_arn_components, 0, length(local.model_publish_arn_components) - 1))
+  model_publish_task_definition_arn_wildcard_version = "${local.model_publish_task_definition_family}:*"
 
   # Similar to the above, prefer the discover-publish task definition family to a 
   # specific revision. This prevents the old revision from going stale if a 
   # deployment occurs while publishing.
   discover_publish_arn_components = split(":", aws_ecs_task_definition.ecs_task_definition.arn)
   discover_publish_task_definition_family = join(":", slice(local.discover_publish_arn_components, 0, length(local.discover_publish_arn_components) - 1))
+  discover_publish_task_definition_arn_wildcard_version = "${local.discover_publish_task_definition_family}:*"
 }


### PR DESCRIPTION
## Changes Proposed

On October 15 AWS will require task definition ARNs used as resources in IAM policies for certain actions to either include a specific version suffix or a wildcard suffix to use the latest version. This PR updates an IAM policy to use the wildcard suffix.

See ticket for details, including the original email from AWS.

[Update IAM Policies for change to ECS Authorization](https://app.clickup.com/t/8688znju1)

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
