### PR TITLE
868f69jn3 metadata-publish IAM permissions

### DIFF
--- a/discover-publish/terraform/iam.tf
+++ b/discover-publish/terraform/iam.tf
@@ -306,6 +306,7 @@ data "aws_iam_policy_document" "sfn_state_machine_iam_policy_document" {
     resources = [
       local.discover_publish_task_definition_arn_wildcard_version,
       local.model_publish_task_definition_arn_wildcard_version,
+      local.metadata_publish_task_definition_arn_wildcard_version,
     ]
   }
 
@@ -363,6 +364,7 @@ data "aws_iam_policy_document" "sfn_state_machine_iam_policy_document" {
     resources = [
       aws_iam_role.ecs_task_iam_role.arn,
       data.terraform_remote_state.model_publish.outputs.ecs_task_iam_role_arn,
+      data.terraform_remote_state.metadata_publish.outputs.metadata_publish_ecs_task_iam_role_arn,
     ]
   }
 


### PR DESCRIPTION
## Description
**ClickUp Ticket:** [868f69jn3](https://app.clickup.com/t/868f69jn3)

**Related PR:** https://github.com/Pennsieve/discover-publish/pull/20

Previous PR was missing IAM permission for discover publish step function to invoke the metadata-publish ECS task, resulting in: 
```
{
  "cause": "User: arn:aws:sts::941165240011:assumed-role/dev-discover-publish-state-machine-role-use1/cVEjJglAahYbKWLJjjKKNMFpaakQknUi is not authorized to perform: iam:PassRole on resource: arn:aws:iam::941165240011:role/dev-metadata-publish-ecs-task-role-use1 because no identity-based policy allows the iam:PassRole action (Service: AmazonECS; Status Code: 400; Error Code: AccessDeniedException; Request ID: 9d5ab5a2-350d-48b0-b4bc-afccb89afebd; Proxy: null)",
  "error": "ECS.AccessDeniedException",
  "resource": "runTask.sync",
  "resourceType": "ecs"
}
```

## Terraform Plan
```
Terraform will perform the following actions:

  # module.service_module.aws_iam_policy.sfn_state_machine_iam_policy will be updated in-place
  ~ resource "aws_iam_policy" "sfn_state_machine_iam_policy" {
        id        = "arn:aws:iam::941165240011:policy/dev-discover-publish-state-machine-policy-use1"
        name      = "dev-discover-publish-state-machine-policy-use1"
      ~ policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            "arn:aws:ecs:us-east-1:941165240011:task-definition/dev-model-publish-use1:*",
                          + "arn:aws:ecs:us-east-1:941165240011:task-definition/dev-metadata-publish-use1:*",
                            "arn:aws:ecs:us-east-1:941165240011:task-definition/dev-discover-publish-use1:*",
                        ]
                        # (3 unchanged elements hidden)
                    },
                    {
                        Action   = [
                            "ecs:StopTask",
                            "ecs:DescribeTasks",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                        Sid      = "TaskControl"
                    },
                    # (1 unchanged element hidden)
                    {
                        Action   = "lambda:InvokeFunction"
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:lambda:us-east-1:941165240011:function:dev-discover-s3clean-lambda-use1",
                            "arn:aws:lambda:us-east-1:941165240011:function:dev-discover-pgdump-lambda-use1",
                        ]
                        Sid      = "InvokeLambda"
                    },
                  ~ {
                      ~ Resource = [
                            "arn:aws:iam::941165240011:role/dev-model-publish-ecs-task-role-use1",
                          + "arn:aws:iam::941165240011:role/dev-metadata-publish-ecs-task-role-use1",
                            "arn:aws:iam::941165240011:role/dev-discover-publish-ecs-task-role-use1",
                        ]
                        # (3 unchanged elements hidden)
                    },
                    {
                        Action   = "sqs:SendMessage"
                        Effect   = "Allow"
                        Resource = "arn:aws:sqs:us-east-1:941165240011:dev-discover-publish-queue-use1"
                        Sid      = "SQSSendMessages"
                    },
                    # (1 unchanged element hidden)
                ]
                # (1 unchanged element hidden)
            }
        )
        tags      = {}
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## Checklist
- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.