### PR TITLE
Fix no file from metadata publish

### DIFF
--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -282,7 +282,9 @@ object Publish extends StrictLogging {
       metadata <- downloadFromS3[ExportedMetadataResult](
         container,
         metadataManifestKey(container)
-      )
+      ) recover {
+        case _ => ExportedMetadataResult.empty()
+      }
 
       _ = logger.info(s"Writing final manifest file: $MANIFEST_FILENAME")
 

--- a/discover-publish/src/main/scala/com/pennsieve/publish/models/Publishing.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/models/Publishing.scala
@@ -94,6 +94,9 @@ object ExportedGraphResult {
 case class ExportedMetadataResult(manifests: List[FileManifest])
 
 object ExportedMetadataResult {
+  def empty(): ExportedMetadataResult =
+    ExportedMetadataResult(manifests = List.empty[FileManifest])
+
   implicit val encoder: Encoder[ExportedMetadataResult] =
     deriveEncoder[ExportedMetadataResult]
   implicit val decoder: Decoder[ExportedMetadataResult] =

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
@@ -671,6 +671,20 @@ class TestPublish
 //      }
     }
 
+    "succeed when metadata service does not emit any model data" in {
+      Publish.publishAssets(publishContainer).await.isRight shouldBe true
+      assert(
+        Try(
+          downloadFile(publishBucket, testKey + Publish.PUBLISH_ASSETS_FILENAME)
+        ).toEither.isRight
+      )
+
+      runModelPublish(publishBucket, testKey)
+      //runMetadataPublish(publishBucket, testKey)
+
+      Publish.finalizeDataset(publishContainer).await shouldBe Right(())
+    }
+
     "create metadata, package objects and public assets in S3 (publish bucket)" in {
 
       // everything under `testKey` should be gone:


### PR DESCRIPTION
## Changes Proposed

When there are no models & records in the new Metadata system, the Metadata Publish task does not produce any output. Under this condition, the Metadata Publish task does not write the intermediate file used to record the names and path of the exported model and record files.

Discover Publish fails with an S3 **NoSuchKey** exception when attempting to load the new Metadata intermediate file. This fails the publishing process, and halts the workflow, and directs the Step Function down the "cleanup due to failure" path. 

An recover handler was added to Discover Publish to the Metadata intermediate file loading step when an exception occurs. The recovery produces an empty `ExportedMetadataResult` and permits Discover Publish to continue.

```scala
      metadata <- downloadFromS3[ExportedMetadataResult](
        container,
        metadataManifestKey(container)
      ) recover {
        case _ => ExportedMetadataResult.empty()
      }
```

A desirable improvement in the `recover` would be to match on the Exception type, but the `downloadFromS3()` function swallows the exception and raises a `com.pennsieve.domain.ThrowableError`. (Perhaps this could be unpacked, but we would need to discuss a slightly different overall approach: see "test notes" below.)

Note: two tests were added to check this correction
- (1) handle the case when there is no Metadata intermediate file
- (2) handle a prospective case where the Metadata Publish task might write a "nothing to publish" result in the intermediate file.

```json
{
    "manifests": []
}
```

In the latter case, Discover Publish reads and consumes the "empty" intermediate Metadata publishing results file. The contained manifest (a list of `FileManifest`) being empty, adds nothing to the aggregate passed to the `writeManifest()` function.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
