### PR TITLE
Add dynamic storage node IAM policies

### DIFF
--- a/discover-publish/terraform/data.tf
+++ b/discover-publish/terraform/data.tf
@@ -126,3 +126,14 @@ data "terraform_remote_state" "africa_south_region" {
     region = "us-east-1"
   }
 }
+
+# Import Account Service (storage node policies)
+data "terraform_remote_state" "account_service" {
+  backend = "s3"
+
+  config = {
+    bucket  = "${var.aws_account}-terraform-state"
+    key     = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/account-service/terraform.tfstate"
+    region  = "us-east-1"
+  }
+}

--- a/discover-publish/terraform/iam-s3.tf
+++ b/discover-publish/terraform/iam-s3.tf
@@ -147,3 +147,8 @@ data "aws_iam_policy_document" "discover_publish_s3_write_access_iam_policy_docu
     ]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "storage_bucket_read" {
+  role       = aws_iam_role.ecs_task_iam_role.name
+  policy_arn = data.terraform_remote_state.account_service.outputs.storage_read_policy_arn
+}


### PR DESCRIPTION
## Summary
- Import account-service terraform remote state
- Attach managed `storage_bucket_read` policy to `ecs_task_iam_role` (in iam-s3.tf)
- Read access needed: service performs server-side S3 copy from org storage buckets to publish buckets

## Context
Part of the distributed storage nodes feature. The account-service maintains dynamically-updated IAM policies that are auto-updated when storage nodes are created/modified/deleted.

## Test plan
- [ ] Terraform plan shows only new policy attachment resources
- [ ] No changes to existing IAM policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)