### PR TITLE
Update AWS SDK versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,8 @@ lazy val auditMiddlewareVersion = "1.0.3"
 lazy val authMiddlewareVersion = "5.1.3"
 lazy val coreVersion = "405-63940d4"
 
-lazy val awsVersion = "1.11.931"
-lazy val awsV2Version = "2.25.19"
+lazy val awsVersion = "1.12.797"
+lazy val awsV2Version = "2.42.28"
 
 lazy val catsVersion = "2.6.1"
 

--- a/discover-publish/src/test/scala/com/pennsieve/publish/DiscoverPublishDockerContainers.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/DiscoverPublishDockerContainers.scala
@@ -64,7 +64,7 @@ object S3DockerContainer {
 
 final class S3DockerContainerImpl
     extends DockerContainer(
-      dockerImage = s"localstack/localstack:stable",
+      dockerImage = s"localstack/localstack:4.12.0",
       exposedPorts = Seq(S3DockerContainer.port),
       env = Map(
         "SERVICES" -> "s3",

--- a/discover-publish/src/test/scala/com/pennsieve/publish/DiscoverPublishDockerContainers.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/DiscoverPublishDockerContainers.scala
@@ -64,7 +64,7 @@ object S3DockerContainer {
 
 final class S3DockerContainerImpl
     extends DockerContainer(
-      dockerImage = s"localstack/localstack:4.12.0",
+      dockerImage = s"localstack/localstack:4.14.0",
       exposedPorts = Seq(S3DockerContainer.port),
       env = Map(
         "SERVICES" -> "s3",


### PR DESCRIPTION
## Changes Proposed

Update AWS SDK versions.

This may resolve the "Cannot parse XML response" errors we are seeing on large-file S3 multipart copy operations.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
