### PR TITLE
Remove dependency on com.pennsieve.migrations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -243,7 +243,6 @@ lazy val discoverPublishSettings = Seq(
     "org.scalamock" %% "scalamock" % "5.2.0" % Test,
     "org.mock-server" % "mockserver-client-java-no-dependencies" % "5.14.0" % Test,
     "com.pennsieve" %% "pennsieve-core" % coreVersion % Test classifier "tests",
-    "com.pennsieve" %% "migrations" % coreVersion % Test,
     "com.dimafeng" %% "testcontainers-scala" % testContainersVersion % Test
   ),
   excludeDependencies ++= unwantedDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ lazy val swaggerAkkaHttpVersion = "1.5.2"
 
 lazy val auditMiddlewareVersion = "1.0.3"
 lazy val authMiddlewareVersion = "5.1.3"
-lazy val coreVersion = "405-63940d4"
+lazy val coreVersion = "422-eaa5968"
 
 lazy val awsVersion = "1.12.797"
 lazy val awsV2Version = "2.42.28"

--- a/discover-publish/src/test/scala/com/pennsieve/publish/CopyFlowIntegrationTest.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/CopyFlowIntegrationTest.scala
@@ -83,7 +83,8 @@ class CopyFlowIntegrationTest
   var targetBucketName: String = _
   var sourceS3Key1: String = _
   var sourceS3Key2: String = _
-  val testOrganization: Organization = sampleOrganization
+  val testOrganization: Organization =
+    Organization("N:organization:32352", "Test org", "test-org", id = 5)
 
   var testDataset: Dataset = _
   var testUser: User = _

--- a/discover-publish/src/test/scala/com/pennsieve/publish/DiscoverPublishDockerContainers.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/DiscoverPublishDockerContainers.scala
@@ -24,7 +24,7 @@ import com.dimafeng.testcontainers.GenericContainer
 import com.pennsieve.test.{
   DockerContainer,
   PostgresContainerImpl,
-  PostgresSeedDockerContainerImpl,
+  PostgresDockerContainerImpl,
   StackedDockerContainer
 }
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
@@ -46,7 +46,7 @@ import java.net.URI
   */
 object DiscoverPublishDockerContainers {
   val postgresContainer: PostgresContainerImpl =
-    new PostgresSeedDockerContainerImpl
+    new PostgresDockerContainerImpl
 
   val s3Container: S3DockerContainerImpl =
     new S3DockerContainerImpl

--- a/discover-publish/src/test/scala/com/pennsieve/publish/DiscoverPublishDockerContainers.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/DiscoverPublishDockerContainers.scala
@@ -24,7 +24,7 @@ import com.dimafeng.testcontainers.GenericContainer
 import com.pennsieve.test.{
   DockerContainer,
   PostgresContainerImpl,
-  PostgresDockerContainerImpl,
+  PostgresSeedDockerContainerImpl,
   StackedDockerContainer
 }
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
@@ -46,7 +46,7 @@ import java.net.URI
   */
 object DiscoverPublishDockerContainers {
   val postgresContainer: PostgresContainerImpl =
-    new PostgresDockerContainerImpl
+    new PostgresSeedDockerContainerImpl
 
   val s3Container: S3DockerContainerImpl =
     new S3DockerContainerImpl

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestMultipartUploader.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestMultipartUploader.scala
@@ -55,8 +55,6 @@ class TestMultipartUploader
   var multipartUploader: MultipartUploader = _
   val maxPartSize = (1024 * 1024).toLong
 
-  val testOrganization: Organization = sampleOrganization
-
   override def afterStart(): Unit = {
     super.afterStart()
 

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPackagesExport.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPackagesExport.scala
@@ -87,7 +87,7 @@ class TestPackagesExport
      * user-actor, use a simple database container to set up initial conditions.
      */
     databaseContainer =
-      bootstrapInsecureDatabaseContainer(config, sampleOrganizationId)
+      bootstrapInsecureDatabaseContainer(config, seedOrganizationId)
     testOrganization = databaseContainer.organization
 
     s3 = new S3(s3Container.s3Client)

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPackagesExport.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPackagesExport.scala
@@ -59,7 +59,7 @@ class TestPackagesExport
 
   implicit var s3: S3 = _
 
-  val testOrganization: Organization = sampleOrganization
+  var testOrganization: Organization = _
 
   var testDataset: Dataset = _
   var testUser: User = _
@@ -86,12 +86,11 @@ class TestPackagesExport
      * Since PublishContainer is scoped to an organization, and requires a
      * user-actor, use a simple database container to set up initial conditions.
      */
-    databaseContainer = InsecureDatabaseContainer(config, testOrganization)
-    databaseContainer.db.run(createSchema(testOrganization.id.toString)).await
-    migrateOrganizationSchema(
-      testOrganization.id,
-      databaseContainer.postgresDatabase
-    )
+    databaseContainer =
+      InsecureDatabaseContainer.fromOrganizationId(config, sampleOrganizationId)
+    testOrganization = databaseContainer.organization
+    resyncUserIdSequence(databaseContainer)
+    resyncDatasetsIdSequence(databaseContainer)
 
     s3 = new S3(s3Container.s3Client)
     val s3Client = s3Container.s3ClientV2

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPackagesExport.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPackagesExport.scala
@@ -87,10 +87,8 @@ class TestPackagesExport
      * user-actor, use a simple database container to set up initial conditions.
      */
     databaseContainer =
-      InsecureDatabaseContainer.fromOrganizationId(config, sampleOrganizationId)
+      bootstrapInsecureDatabaseContainer(config, sampleOrganizationId)
     testOrganization = databaseContainer.organization
-    resyncUserIdSequence(databaseContainer)
-    resyncDatasetsIdSequence(databaseContainer)
 
     s3 = new S3(s3Container.s3Client)
     val s3Client = s3Container.s3ClientV2

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
@@ -24,6 +24,7 @@ import cats.data.EitherT
 import cats.implicits._
 import com.amazonaws.services.s3.model.{ Bucket }
 import com.pennsieve.audit.middleware.TraceId
+import com.pennsieve.test.helpers.AwaitableImplicits.toAwaitable
 import com.pennsieve.clients.{ DatasetAssetClient, S3DatasetAssetClient }
 import com.pennsieve.aws.s3.S3
 import com.pennsieve.core.utilities._
@@ -77,6 +78,39 @@ case class InsecureDatabaseContainer(config: Config, organization: Organization)
   override val postgresUseSSL = false
 }
 
+object InsecureDatabaseContainer {
+
+  case class InsecureOrganizationManagerContainer(config: Config)
+      extends Container
+      with DatabaseContainer
+      with OrganizationManagerContainer {
+    override val postgresUseSSL: Boolean = false
+  }
+
+  def fromOrganizationId(
+    config: Config,
+    organizationId: Int
+  )(implicit
+    ec: ExecutionContext
+  ): InsecureDatabaseContainer = {
+    val orgContainer = InsecureOrganizationManagerContainer(config)
+    try {
+      val organization =
+        orgContainer.organizationManager.get(organizationId).await match {
+          case Right(org) => org
+          case Left(err) =>
+            throw new IllegalStateException(
+              s"Could not load organization $organizationId for test setup — " +
+                s"is the test database seeded with this org? Underlying error: $err"
+            )
+        }
+      InsecureDatabaseContainer(config, organization)
+    } finally {
+      orgContainer.db.close()
+    }
+  }
+}
+
 class TestPublish
     extends AnyWordSpec
     with Matchers
@@ -96,7 +130,7 @@ class TestPublish
   implicit var s3: S3 = _
   var bucket: Bucket = _
 
-  val testOrganization: Organization = sampleOrganization
+  var testOrganization: Organization = _
 
   var testDataset: Dataset = _
   var testUser: User = _
@@ -134,12 +168,11 @@ class TestPublish
      * Since PublishContainer is scoped to an organization, and requires a
      * user-actor, use a simple database container to set up initial conditions.
      */
-    databaseContainer = InsecureDatabaseContainer(config, testOrganization)
-    databaseContainer.db.run(createSchema(testOrganization.id.toString)).await
-    migrateOrganizationSchema(
-      testOrganization.id,
-      databaseContainer.postgresDatabase
-    )
+    databaseContainer =
+      InsecureDatabaseContainer.fromOrganizationId(config, sampleOrganizationId)
+    testOrganization = databaseContainer.organization
+    resyncUserIdSequence(databaseContainer)
+    resyncDatasetsIdSequence(databaseContainer)
 
     s3 = new S3(s3Container.s3Client)
     val s3Client = s3Container.s3ClientV2

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
@@ -169,10 +169,8 @@ class TestPublish
      * user-actor, use a simple database container to set up initial conditions.
      */
     databaseContainer =
-      InsecureDatabaseContainer.fromOrganizationId(config, sampleOrganizationId)
+      bootstrapInsecureDatabaseContainer(config, sampleOrganizationId)
     testOrganization = databaseContainer.organization
-    resyncUserIdSequence(databaseContainer)
-    resyncDatasetsIdSequence(databaseContainer)
 
     s3 = new S3(s3Container.s3Client)
     val s3Client = s3Container.s3ClientV2

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
@@ -169,7 +169,7 @@ class TestPublish
      * user-actor, use a simple database container to set up initial conditions.
      */
     databaseContainer =
-      bootstrapInsecureDatabaseContainer(config, sampleOrganizationId)
+      bootstrapInsecureDatabaseContainer(config, seedOrganizationId)
     testOrganization = databaseContainer.organization
 
     s3 = new S3(s3Container.s3Client)

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
@@ -198,10 +198,8 @@ class TestPublishS3Requests
      * user-actor, use a simple database container to set up initial conditions.
      */
     databaseContainer =
-      InsecureDatabaseContainer.fromOrganizationId(config, sampleOrganizationId)
+      bootstrapInsecureDatabaseContainer(config, sampleOrganizationId)
     testOrganization = databaseContainer.organization
-    resyncUserIdSequence(databaseContainer)
-    resyncDatasetsIdSequence(databaseContainer)
     mockServerClient = mockServerContainer.mockServerClient
 
   }

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
@@ -104,7 +104,7 @@ class TestPublishS3Requests
     with ValueHelper
     with EitherBePropertyMatchers {
 
-  val testOrganization: Organization = sampleOrganization
+  var testOrganization: Organization = _
 
   val publishAssetResult: PublishAssetResult = PublishAssetResult.apply(
     externalIdToPackagePath = Map.empty,
@@ -160,26 +160,7 @@ class TestPublishS3Requests
       orcid = Some("0000-0001-0221-1986")
     )
 
-  val datasetManifest: DatasetMetadataV5_0 = DatasetMetadataV5_0(
-    pennsieveDatasetId = 100,
-    version = 10,
-    revision = None,
-    name = "name",
-    description = "description",
-    creator = owner,
-    contributors = List(contributor),
-    sourceOrganization = testOrganization.name,
-    keywords = List("test"),
-    datePublished = LocalDate.now(),
-    license = None,
-    `@id` = s"https://doi.org/$testDoi",
-    collections = Some(List(collection)),
-    relatedPublications = Some(List(externalPublication)),
-    files = List.empty,
-    pennsieveSchemaVersion = "5.0",
-    release = None,
-    references = None
-  )
+  var datasetManifest: DatasetMetadataV5_0 = _
 
   class DatasetFileInfo(
     val sourceKey: String,
@@ -216,12 +197,11 @@ class TestPublishS3Requests
      * Since PublishContainer is scoped to an organization, and requires a
      * user-actor, use a simple database container to set up initial conditions.
      */
-    databaseContainer = InsecureDatabaseContainer(config, testOrganization)
-    databaseContainer.db.run(createSchema(testOrganization.id.toString)).await
-    migrateOrganizationSchema(
-      testOrganization.id,
-      databaseContainer.postgresDatabase
-    )
+    databaseContainer =
+      InsecureDatabaseContainer.fromOrganizationId(config, sampleOrganizationId)
+    testOrganization = databaseContainer.organization
+    resyncUserIdSequence(databaseContainer)
+    resyncDatasetsIdSequence(databaseContainer)
     mockServerClient = mockServerContainer.mockServerClient
 
   }
@@ -263,6 +243,27 @@ class TestPublishS3Requests
 
     datasetFileInfos =
       addPackagesToDataset(databaseContainer, publishContainer.fileManager)
+
+    datasetManifest = DatasetMetadataV5_0(
+      pennsieveDatasetId = 100,
+      version = 10,
+      revision = None,
+      name = "name",
+      description = "description",
+      creator = owner,
+      contributors = List(contributor),
+      sourceOrganization = testOrganization.name,
+      keywords = List("test"),
+      datePublished = LocalDate.now(),
+      license = None,
+      `@id` = s"https://doi.org/$testDoi",
+      collections = Some(List(collection)),
+      relatedPublications = Some(List(externalPublication)),
+      files = List.empty,
+      pennsieveSchemaVersion = "5.0",
+      release = None,
+      references = None
+    )
 
   }
 

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
@@ -198,7 +198,7 @@ class TestPublishS3Requests
      * user-actor, use a simple database container to set up initial conditions.
      */
     databaseContainer =
-      bootstrapInsecureDatabaseContainer(config, sampleOrganizationId)
+      bootstrapInsecureDatabaseContainer(config, seedOrganizationId)
     testOrganization = databaseContainer.organization
     mockServerClient = mockServerContainer.mockServerClient
 

--- a/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
@@ -48,6 +48,7 @@ import com.pennsieve.models.{
 }
 import com.pennsieve.test.helpers.AwaitableImplicits.toAwaitable
 import com.pennsieve.traits.PostgresProfile.api._
+import com.typesafe.config.Config
 import org.scalatest.Assertion
 import org.scalatest.EitherValues._
 import org.scalatest.matchers.should.Matchers
@@ -196,6 +197,23 @@ trait ValueHelper extends Matchers {
       references = references,
       pennsieveSchemaVersion = pennsieveSchemaVersion
     )
+  }
+
+  // returns an InsecureDatabaseContainer scoped to the org with the given id. Assumes that the
+  // org already exists in DB as part of our pennsievedb seed image.
+  // It therefor also uses setval on the id sequences for users and datasets so that creating
+  // new rows there will not result in id conflicts with users and datasets already in the seed.
+  def bootstrapInsecureDatabaseContainer(
+    config: Config,
+    organizationId: Int
+  )(implicit
+    ec: ExecutionContext
+  ): InsecureDatabaseContainer = {
+    val dbContainer =
+      InsecureDatabaseContainer.fromOrganizationId(config, organizationId)
+    resyncUserIdSequence(dbContainer)
+    resyncDatasetsIdSequence(dbContainer)
+    dbContainer
   }
 
   // seeded users have explicit ids; advance the sequence past them so inserts don't collide.

--- a/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
@@ -83,6 +83,9 @@ trait ValueHelper extends Matchers {
   val sampleOrganization: Organization =
     Organization("N:organization:32352", "Test org", "test-org", id = 5)
 
+  // sampleOrganizationId is an org that already exists in the seed pennsievedb Docker container
+  val sampleOrganizationId = 2
+
   val ownerUser: User =
     User(
       nodeId = " N:user:02a6e643-2f6c-4597-a9fe-b75f12a2ad32",
@@ -193,6 +196,33 @@ trait ValueHelper extends Matchers {
       references = references,
       pennsieveSchemaVersion = pennsieveSchemaVersion
     )
+  }
+
+  // seeded users have explicit ids; advance the sequence past them so inserts don't collide.
+  def resyncUserIdSequence(
+    databaseContainer: InsecureDatabaseContainer
+  ): Unit = {
+    databaseContainer.db
+      .run(
+        sql"""SELECT setval(pg_get_serial_sequence('pennsieve.users', 'id'),
+                      (SELECT MAX(id) FROM pennsieve.users))"""
+          .as[Long]
+      )
+      .await
+  }
+
+  // seeded datasets have explicit ids; advance the sequence past them so inserts don't collide.
+  def resyncDatasetsIdSequence(
+    databaseContainer: InsecureDatabaseContainer
+  ): Unit = {
+    val qualified = s""""${databaseContainer.organization.schemaId}".datasets"""
+    databaseContainer.db
+      .run(
+        sql"""SELECT setval(pg_get_serial_sequence($qualified, 'id'),
+                          (SELECT MAX(id) FROM #$qualified))"""
+          .as[Long]
+      )
+      .await
   }
 
   def createUser(

--- a/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
@@ -81,11 +81,8 @@ trait ValueHelper extends Matchers {
   val copyParallelism = 5
   val testDoi: String = "10.38492/234.7"
 
-  val sampleOrganization: Organization =
-    Organization("N:organization:32352", "Test org", "test-org", id = 5)
-
-  // sampleOrganizationId is an org that already exists in the seed pennsievedb Docker container
-  val sampleOrganizationId = 2
+  // seedOrganizationId is an org that already exists in the seed pennsievedb Docker container
+  val seedOrganizationId = 2
 
   val ownerUser: User =
     User(


### PR DESCRIPTION
## Changes Proposed

The tests here currently use an empty `pennsievedb` image, unseeded with organization schemas. The tests create a schema and use a method to run the `com.pennsieve.migrations` on this org schema. 

The PR https://github.com/Pennsieve/pennsieve-api/pull/378 removed this method as well as the `com.pennsieve.migrations` sub-project. So this PR updates to the latest pennsieve core version. This version only exposes the seeded version of the `pennsievedb` image. Now the tests can assume an up-to-date organization already exists in the DB and do not need to create or migrate a new org schema.


## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
